### PR TITLE
Fix code scanning alert no. 3: Regular expression injection

### DIFF
--- a/bin/line-commenter-tool.js
+++ b/bin/line-commenter-tool.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import chalk from 'chalk';
-import processFile from '../src/index.js';
+import processFile, { escapeRegExp } from '../src/index.js';
 import { readFile } from 'fs/promises';
 import { resolve } from 'path';
 
@@ -104,7 +104,8 @@ ${format.usage('Notes:')}
 
     try {
         const options = { silent, multiline };
-        await processFile(action, filename, regexPattern, strings, options);
+        const sanitizedRegexPattern = escapeRegExp(regexPattern);
+        await processFile(action, filename, sanitizedRegexPattern, strings, options);
         if (!silent) {
             console.log(format.success(filename));
         }

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ export async function processFile(action, filename, regexPattern, strings, optio
                     return `${startPattern} ${match.trim()} ${endPattern}`;
                 });
             } else if (actionType === 'uncomment') {
-                content = content.replace(blockCommentRegex, match => match.replace(new RegExp(`^\s*${startPattern}\s*|\s*${endPattern}\s*$`, 'g'), ''));
+                content = content.replace(blockCommentRegex, match => match.replace(new RegExp(`^\\s*${startPattern}\\s*|\\s*${endPattern}\\s*$`, 'g'), ''));
             }
         };
 

--- a/src/index.js
+++ b/src/index.js
@@ -75,13 +75,13 @@ export async function processFile(action, filename, regexPattern, strings, optio
         const processStringComments = (strings, action) => {
             strings.forEach((string) => {
                 const escapedString = escapeRegExp(string);
-                const commentRegex = new RegExp(`^([\s]*)${action === 'uncomment' ? startComment + '\\s*' : ''}(.*${escapedString}.*)$`, 'gm');
+                const commentRegex = new RegExp(`^([\s]*)${action === 'uncomment' ? startComment + '\s*' : ''}(.*${escapedString}.*)$`, 'gm');
                 processSingleLineComment(commentRegex, action);
             });
         };
 
         const processRegexComments = (safeRegexPattern, action) => {
-            const regexCommentRegex = new RegExp(`^([\s]*)${action === 'uncomment' ? startComment + '\\s*' : ''}(.*${safeRegexPattern}.*)$`, 'gm');
+            const regexCommentRegex = new RegExp(`^([\s]*)${action === 'uncomment' ? startComment + '\s*' : ''}(.*${safeRegexPattern}.*)$`, 'gm');
             processSingleLineComment(regexCommentRegex, action);
         };
 

--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,7 @@ export async function processFile(action, filename, regexPattern, strings, optio
                     // Process Python multiline strings first to avoid modifying them
                     processPythonMultilineStrings(action);
 
-                    const regex = new RegExp(`^\s*${regexPattern}`, 'gm');
+                    const regex = new RegExp(`^\\s*${regexPattern}`, 'gm');
                     content = content.replace(regex, (match) => {
                         if (match.trimStart().startsWith(commentSymbol)) {
                             return match;

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ export async function processFile(action, filename, regexPattern, strings, optio
 
         const processMultilineBlockComment = (startPattern, endPattern, actionType) => {
             const blockCommentRegex = new RegExp(
-                `^([\s]*)${startPattern}\s*[\S]*?${endPattern}`,
+                new RegExp(`^([\\s]*)${startPattern}\\s*[\\S]*?${endPattern}`, 'gm'),
                 'gm'
             );
             if (actionType === 'comment') {

--- a/src/index.js
+++ b/src/index.js
@@ -54,12 +54,12 @@ export async function processFile(action, filename, regexPattern, strings, optio
         };
 
         const processPythonComment = (safeRegexPattern) => {
-            const regex = new RegExp(`^\\s*${safeRegexPattern}`, 'gm');
-            content = content.replace(regex, (match) => {
-                if (match.trimStart().startsWith(commentSymbol)) {
+            const regex = new RegExp(`^(\s*)(.*?)(${safeRegexPattern})(.*)$`, 'gm');
+            content = content.replace(regex, (match, p1, p2, p3, p4) => {
+                if (p2.trimStart().startsWith(commentSymbol)) {
                     return match;
                 }
-                return `${startComment} ${match}`;
+                return `${p1}${startComment} ${p2}${p3}${p4}`;
             });
         };
 
@@ -74,13 +74,13 @@ export async function processFile(action, filename, regexPattern, strings, optio
         const processStringComments = (strings, action) => {
             strings.forEach((string) => {
                 const escapedString = escapeRegExp(string);
-                const commentRegex = new RegExp(`^([\\s]*)${action === 'uncomment' ? startComment + '\\s*' : ''}(.*${escapedString}.*)$`, 'gm');
+                const commentRegex = new RegExp(`^([\s]*)${action === 'uncomment' ? startComment + '\s*' : ''}(.*${escapedString}.*)$`, 'gm');
                 processSingleLineComment(commentRegex, action);
             });
         };
 
         const processRegexComments = (safeRegexPattern, action) => {
-            const regexCommentRegex = new RegExp(`^([\\s]*)${action === 'uncomment' ? startComment + '\\s*' : ''}(.*${safeRegexPattern}.*)$`, 'gm');
+            const regexCommentRegex = new RegExp(`^([\s]*)${action === 'uncomment' ? startComment + '\s*' : ''}(.*${safeRegexPattern}.*)$`, 'gm');
             processSingleLineComment(regexCommentRegex, action);
         };
 

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ export async function processFile(action, filename, regexPattern, strings, optio
 
         const processMultilineBlockComment = (startPattern, endPattern, actionType) => {
             const blockCommentRegex = new RegExp(
-                `^([\s]*)${startPattern}\s*[\s\S]*?${endPattern}`,
+                `^([\s]*)${startPattern}\s*[\S]*?${endPattern}`,
                 'gm'
             );
             if (actionType === 'comment') {

--- a/src/index.js
+++ b/src/index.js
@@ -111,13 +111,13 @@ export async function processFile(action, filename, regexPattern, strings, optio
                     if (strings && strings.length > 0) {
                         strings.forEach((string) => {
                             const escapedString = escapeRegExp(string);
-                            const commentRegex = new RegExp(`^([\s]*)${action === 'uncomment' ? startComment + '\s*' : ''}(.*${escapedString}.*)$`, 'gm');
+                            const commentRegex = new RegExp(`^([\\s]*)${action === 'uncomment' ? startComment + '\\s*' : ''}(.*${escapedString}.*)$`, 'gm');
                             processSingleLineComment(commentRegex, action);
                         });
                     }
 
                     if (regexPattern) {
-                        const regexCommentRegex = new RegExp(`^([\s]*)${action === 'uncomment' ? startComment + '\s*' : ''}(.*${regexPattern}.*)$`, 'gm');
+                        const regexCommentRegex = new RegExp(`^([\\s]*)${action === 'uncomment' ? startComment + '\\s*' : ''}(.*${regexPattern}.*)$`, 'gm');
                         processSingleLineComment(regexCommentRegex, action);
                     }
                 }

--- a/src/index.js
+++ b/src/index.js
@@ -53,22 +53,35 @@ export async function processFile(action, filename, regexPattern, strings, optio
             }
         };
 
-        const processMultilineBlockComment = (startPattern, endPattern, actionType) => {
-            const blockCommentRegex = new RegExp(
-                `^([\\s]*)${startPattern}\\s*[\\s\\S]*?${endPattern}`,
-                'gm'
-            );
-            if (actionType === 'comment') {
-                content = content.replace(blockCommentRegex, match => {
-                    // Properly handle nested block comments
-                    if (match.trim().startsWith(startPattern)) {
-                        return match;
-                    }
-                    return `${startPattern} ${match.trim()} ${endPattern}`;
-                });
-            } else if (actionType === 'uncomment') {
-                content = content.replace(blockCommentRegex, match => match.replace(new RegExp(`^\\s*${startPattern}\\s*|\\s*${endPattern}\\s*$`, 'g'), ''));
-            }
+        const processPythonComment = (safeRegexPattern) => {
+            const regex = new RegExp(`^\\s*${safeRegexPattern}`, 'gm');
+            content = content.replace(regex, (match) => {
+                if (match.trimStart().startsWith(commentSymbol)) {
+                    return match;
+                }
+                return `${startComment} ${match}`;
+            });
+        };
+
+        const processCssComment = (safeRegexPattern) => {
+            const regex = new RegExp(safeRegexPattern, 'g');
+            content = content.replace(regex, (match) => {
+                // Wrap matched content in block comments
+                return `/* ${match.trim()} */`;
+            });
+        };
+
+        const processStringComments = (strings, action) => {
+            strings.forEach((string) => {
+                const escapedString = escapeRegExp(string);
+                const commentRegex = new RegExp(`^([\\s]*)${action === 'uncomment' ? startComment + '\\s*' : ''}(.*${escapedString}.*)$`, 'gm');
+                processSingleLineComment(commentRegex, action);
+            });
+        };
+
+        const processRegexComments = (safeRegexPattern, action) => {
+            const regexCommentRegex = new RegExp(`^([\\s]*)${action === 'uncomment' ? startComment + '\\s*' : ''}(.*${safeRegexPattern}.*)$`, 'gm');
+            processSingleLineComment(regexCommentRegex, action);
         };
 
         if (action === 'comment' || action === 'uncomment') {
@@ -80,32 +93,20 @@ export async function processFile(action, filename, regexPattern, strings, optio
                     processMultilineBlockComment(startPattern, endPattern, action);
                 }
             } else {
+                // Sanitize regexPattern before using it in a regex
+                const safeRegexPattern = escapeRegExp(regexPattern);
+
                 if (filename.endsWith('.py') && action === 'comment') {
-                    const regex = new RegExp(`^\\s*${regexPattern}`, 'gm');
-                    content = content.replace(regex, (match) => {
-                        if (match.trimStart().startsWith(commentSymbol)) {
-                            return match;
-                        }
-                        return `${startComment} ${match}`;
-                    });
+                    processPythonComment(safeRegexPattern);
                 } else if (filename.endsWith('.css') && action === 'comment') {
-                    const regex = new RegExp(regexPattern, 'g');
-                    content = content.replace(regex, (match) => {
-                        // Wrap matched content in block comments
-                        return `/* ${match.trim()} */`;
-                    });
+                    processCssComment(safeRegexPattern);
                 } else {
                     if (strings && strings.length > 0) {
-                        strings.forEach((string) => {
-                            const escapedString = escapeRegExp(string);
-                            const commentRegex = new RegExp(`^([\\s]*)${action === 'uncomment' ? startComment + '\\s*' : ''}(.*${escapedString}.*)$`, 'gm');
-                            processSingleLineComment(commentRegex, action);
-                        });
+                        processStringComments(strings, action);
                     }
 
                     if (regexPattern) {
-                        const regexCommentRegex = new RegExp(`^([\\s]*)${action === 'uncomment' ? startComment + '\\s*' : ''}(.*${regexPattern}.*)$`, 'gm');
-                        processSingleLineComment(regexCommentRegex, action);
+                        processRegexComments(safeRegexPattern, action);
                     }
                 }
             }

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ export async function processFile(action, filename, regexPattern, strings, optio
 
         const processMultilineBlockComment = (startPattern, endPattern, actionType) => {
             const blockCommentRegex = new RegExp(
-                `^([\s]*)${startPattern}\s*[\s\S]*?${endPattern}`,
+                `^([\\s]*)${startPattern}\\s*[\\s\\S]*?${endPattern}`,
                 'gm'
             );
             if (actionType === 'comment') {
@@ -67,7 +67,7 @@ export async function processFile(action, filename, regexPattern, strings, optio
                     return `${startPattern} ${match.trim()} ${endPattern}`;
                 });
             } else if (actionType === 'uncomment') {
-                content = content.replace(blockCommentRegex, match => match.replace(new RegExp(`^\s*${startPattern}\s*|\s*${endPattern}\s*$`, 'g'), ''));
+                content = content.replace(blockCommentRegex, match => match.replace(new RegExp(`^\\s*${startPattern}\\s*|\\s*${endPattern}\\s*$`, 'g'), ''));
             }
         };
 
@@ -81,7 +81,7 @@ export async function processFile(action, filename, regexPattern, strings, optio
                 }
             } else {
                 if (filename.endsWith('.py') && action === 'comment') {
-                    const regex = new RegExp(`^\s*${regexPattern}`, 'gm');
+                    const regex = new RegExp(`^\\s*${regexPattern}`, 'gm');
                     content = content.replace(regex, (match) => {
                         if (match.trimStart().startsWith(commentSymbol)) {
                             return match;
@@ -98,13 +98,13 @@ export async function processFile(action, filename, regexPattern, strings, optio
                     if (strings && strings.length > 0) {
                         strings.forEach((string) => {
                             const escapedString = escapeRegExp(string);
-                            const commentRegex = new RegExp(`^([\s]*)${action === 'uncomment' ? startComment + '\s*' : ''}(.*${escapedString}.*)$`, 'gm');
+                            const commentRegex = new RegExp(`^([\\s]*)${action === 'uncomment' ? startComment + '\\s*' : ''}(.*${escapedString}.*)$`, 'gm');
                             processSingleLineComment(commentRegex, action);
                         });
                     }
 
                     if (regexPattern) {
-                        const regexCommentRegex = new RegExp(`^([\s]*)${action === 'uncomment' ? startComment + '\s*' : ''}(.*${regexPattern}.*)$`, 'gm');
+                        const regexCommentRegex = new RegExp(`^([\\s]*)${action === 'uncomment' ? startComment + '\\s*' : ''}(.*${regexPattern}.*)$`, 'gm');
                         processSingleLineComment(regexCommentRegex, action);
                     }
                 }

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ export async function processFile(action, filename, regexPattern, strings, optio
         const processStringComments = (strings, action) => {
             strings.forEach((string) => {
                 const escapedString = escapeRegExp(string);
-                const commentRegex = new RegExp(`^([\s]*)${action === 'uncomment' ? startComment + '\s*' : ''}(.*${escapedString}.*)$`, 'gm');
+                const commentRegex = new RegExp(`^([\\s]*)${action === 'uncomment' ? startComment + '\\s*' : ''}(.*${escapedString}.*)$`, 'gm');
                 processSingleLineComment(commentRegex, action);
             });
         };

--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,8 @@ export async function processFile(action, filename, regexPattern, strings, optio
                 }
             } else {
                 if (filename.endsWith('.py') && action === 'comment') {
-                    const regex = new RegExp(`^\\s*${regexPattern}`, 'gm');
+                    const sanitizedRegexPattern = escapeRegExp(regexPattern);
+                    const regex = new RegExp(`^\\s*${sanitizedRegexPattern}`, 'gm');
                     content = content.replace(regex, (match) => {
                         if (match.trim().startsWith(commentSymbol)) {
                             return match;
@@ -89,7 +90,8 @@ export async function processFile(action, filename, regexPattern, strings, optio
                         return `${startComment} ${match}`;
                     });
                 } else if (filename.endsWith('.css') && action === 'comment') {
-                    const regex = new RegExp(regexPattern, 'g');
+                    const sanitizedRegexPattern = escapeRegExp(regexPattern);
+                    const regex = new RegExp(sanitizedRegexPattern, 'g');
                     content = content.replace(regex, (match) => {
                         // Wrap matched content in block comments
                         return `/* ${match.trim()} */`;
@@ -104,8 +106,8 @@ export async function processFile(action, filename, regexPattern, strings, optio
                     }
 
                     if (regexPattern) {
-                        const escapedRegex = escapeRegExp(regexPattern);
-                        const regexCommentRegex = new RegExp(`^([\\s]*)${action === 'uncomment' ? startComment + '\\s*' : ''}(.*${escapedRegex}.*)$`, 'gm');
+                        const sanitizedRegexPattern = escapeRegExp(regexPattern);
+                        const regexCommentRegex = new RegExp(`^([\\s]*)${action === 'uncomment' ? startComment + '\\s*' : ''}(.*${sanitizedRegexPattern}.*)$`, 'gm');
                         processSingleLineComment(regexCommentRegex, action);
                     }
                 }

--- a/src/index.js
+++ b/src/index.js
@@ -54,12 +54,13 @@ export async function processFile(action, filename, regexPattern, strings, optio
         };
 
         const processPythonComment = (safeRegexPattern) => {
-            const regex = new RegExp(`^(\s*)(.*?)(${safeRegexPattern})(.*)$`, 'gm');
-            content = content.replace(regex, (match, p1, p2, p3, p4) => {
+            const regex = new RegExp(`^(\s*)([^#].*?${safeRegexPattern}.*)$`, 'gm');
+            content = content.replace(regex, (match, p1, p2) => {
+                // Ensure the line is commented unless it already starts with a comment
                 if (p2.trimStart().startsWith(commentSymbol)) {
                     return match;
                 }
-                return `${p1}${startComment} ${p2}${p3}${p4}`;
+                return `${p1}${startComment} ${p2}`;
             });
         };
 
@@ -74,13 +75,13 @@ export async function processFile(action, filename, regexPattern, strings, optio
         const processStringComments = (strings, action) => {
             strings.forEach((string) => {
                 const escapedString = escapeRegExp(string);
-                const commentRegex = new RegExp(`^([\s]*)${action === 'uncomment' ? startComment + '\s*' : ''}(.*${escapedString}.*)$`, 'gm');
+                const commentRegex = new RegExp(`^([\s]*)${action === 'uncomment' ? startComment + '\\s*' : ''}(.*${escapedString}.*)$`, 'gm');
                 processSingleLineComment(commentRegex, action);
             });
         };
 
         const processRegexComments = (safeRegexPattern, action) => {
-            const regexCommentRegex = new RegExp(`^([\s]*)${action === 'uncomment' ? startComment + '\s*' : ''}(.*${safeRegexPattern}.*)$`, 'gm');
+            const regexCommentRegex = new RegExp(`^([\s]*)${action === 'uncomment' ? startComment + '\\s*' : ''}(.*${safeRegexPattern}.*)$`, 'gm');
             processSingleLineComment(regexCommentRegex, action);
         };
 
@@ -94,7 +95,7 @@ export async function processFile(action, filename, regexPattern, strings, optio
                 }
             } else {
                 // Sanitize regexPattern before using it in a regex
-                const safeRegexPattern = escapeRegExp(regexPattern);
+                const safeRegexPattern = regexPattern ? escapeRegExp(regexPattern) : '';
 
                 if (filename.endsWith('.py') && action === 'comment') {
                     processPythonComment(safeRegexPattern);


### PR DESCRIPTION
Fixes [https://github.com/darkmastermindz/line-commenter-tool/security/code-scanning/3](https://github.com/darkmastermindz/line-commenter-tool/security/code-scanning/3)

To fix the problem, we need to sanitize the `regexPattern` before using it to construct a regular expression. This can be done by using the `escapeRegExp` function to escape any special characters in the `regexPattern`. This ensures that the user cannot insert characters that have special meaning in regular expressions, thus preventing regular expression injection.

- Modify the `processFile` function in `src/index.js` to sanitize the `regexPattern` using the `escapeRegExp` function.
- Ensure that the `regexPattern` is sanitized before it is used to construct any regular expressions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
